### PR TITLE
add command and basic tslinthelpers

### DIFF
--- a/tslint/extension.ts
+++ b/tslint/extension.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
-import { workspace, ExtensionContext } from 'vscode';
+import * as vscode from "vscode";
 import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions } from 'vscode-languageclient';
 
-export function activate(context: ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
 
 	// We need to go one level up since an extension compile the js code into
 	// the output folder.
@@ -10,17 +10,120 @@ export function activate(context: ExtensionContext) {
 	let debugOptions = { execArgv: ["--nolazy", "--debug=6004"] };
 	let serverOptions: ServerOptions = {
 		run: { module: serverModulePath },
-		debug: { module: serverModulePath, options: debugOptions}
+		debug: { module: serverModulePath, options: debugOptions }
 	};
 
 	let clientOptions: LanguageClientOptions = {
 		documentSelector: ['typescript', 'typescriptreact'],
 		synchronize: {
 			configurationSection: 'tslint',
-			fileEvents: workspace.createFileSystemWatcher('**/tslint.json')
+			fileEvents: vscode.workspace.createFileSystemWatcher('**/tslint.json')
 		}
 	};
 
 	let client = new LanguageClient('TS Linter', serverOptions, clientOptions);
 	context.subscriptions.push(new SettingMonitor(client, 'tslint.enable').start());
+
+	let tsLintHelper = new TsLintHelperProvider();
+	tsLintHelper.activate(context.subscriptions);
+	vscode.languages.registerCodeActionsProvider('typescript', tsLintHelper);
 }
+
+export class TsLintHelperProvider implements vscode.CodeActionProvider {
+	private tsLintHelpers: TsLintHelper[] = [];
+	private static commandId: string = 'tslint.helper';
+	private command: vscode.Disposable;
+
+	public activate(subscriptions: vscode.Disposable[]) {
+		this.command = vscode.commands.registerCommand(TsLintHelperProvider.commandId, this.runCodeAction, this);
+		subscriptions.push(this);
+
+		let helper: TsLintHelper;
+		helper = {
+			tsLintCode: "one-line",
+			tsLintMessage: "missing whitespace",
+			tsLintHelperMessage: "Add a whitespace?",
+			runCodeAction: function(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): any {
+				console.log("tsLint helper missing whitespace");
+				let codeBefore = document.getText(diagnostic.range);
+				let codeAfter = " " + codeBefore;
+				let edit = new vscode.WorkspaceEdit();
+				edit.replace(document.uri, diagnostic.range, codeAfter);
+				console.log("Before:>", codeBefore, "< after:>", codeAfter, "<");
+				return vscode.workspace.applyEdit(edit);
+			}
+		}
+		this.tsLintHelpers.push(helper);
+
+		helper = {
+			tsLintCode: "one-line",
+			tsLintMessage: "missing semicolon",
+			tsLintHelperMessage: "Add semicolon?",
+			runCodeAction: function(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): any {
+				console.log("tsLint helper missing semicolon");
+				let codeBefore = document.getText(diagnostic.range);
+				let codeAfter = codeBefore + ";";
+				let edit = new vscode.WorkspaceEdit();
+				edit.replace(document.uri, diagnostic.range, codeAfter);
+				console.log("Before:>", codeBefore, "< after:>", codeAfter, "<");
+				return vscode.workspace.applyEdit(edit);
+			}
+		}
+		this.tsLintHelpers.push(helper);
+
+		helper = {
+			tsLintCode: "quotemark",
+			tsLintMessage: "' should be \"",
+			tsLintHelperMessage: "Replace ' by \" ",
+			runCodeAction: function(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): any {
+				console.log("tsLint helper replace ' by \"");
+				let codeBefore = document.getText(diagnostic.range);
+				let codeAfter = "\"" + codeBefore.slice(1, codeBefore.length - 2) + "\"";
+				let edit = new vscode.WorkspaceEdit();
+				edit.replace(document.uri, diagnostic.range, codeAfter);
+				console.log("Before:>", codeBefore, "< after:>", codeAfter, "<");
+				return vscode.workspace.applyEdit(edit);
+			}
+		}
+		this.tsLintHelpers.push(helper);
+	}
+
+	public dispose(): void {
+		this.command.dispose();
+	}
+
+	public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.Command[] {
+		let diagnostic: vscode.Diagnostic = context.diagnostics[0];
+		console.log("provideCodeActions:", diagnostic);
+
+		let helper = this.tsLintHelpers.find((h: TsLintHelper, index, obj) => { return h.tsLintMessage === diagnostic.message; });
+		if (helper !== undefined) {
+			return [{
+				title: "tsLintHelper:" + helper.tsLintHelperMessage,
+				command: TsLintHelperProvider.commandId,
+				arguments: [document, diagnostic]
+			}];
+		} else {
+			return null;
+		}
+	}
+
+	private runCodeAction(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): any {
+		console.log("Dans - run - code actions: do something on:", diagnostic);
+
+		let helper = this.tsLintHelpers.find((h: TsLintHelper, index, obj) => { return h.tsLintMessage === diagnostic.message; });
+		if (helper !== undefined) {
+			helper.runCodeAction(document, diagnostic);
+		} else {
+			return null;
+		}
+	}
+}
+
+interface TsLintHelper {
+	tsLintCode: string;
+	tsLintMessage: string;
+	tsLintHelperMessage: string;
+	runCodeAction(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): any;
+}
+


### PR DESCRIPTION
Hi,

 In several cases it's easy to "automatically" solve the tsLint warning. For example, warning about missing whitespace, ' should be ", missing semicolon. 

 In this PR, I propose you:
 * add a new vscode command named: tslint.helper
 * definition of helpers ( the 3 examples above )
 * activate code light bulb if a helper can be run

Let me know if you are interested in, if you may integrated in your repo/extension, in with condition. If not, do you accept that I create my own vscode extension and publish it?

 Thank for your great job.

Sincerely,