### PR TITLE
Ability to exclude files

### DIFF
--- a/tslint-server/package.json
+++ b/tslint-server/package.json
@@ -7,6 +7,7 @@
 	},
 	"private": true,
 	"dependencies": {
+		"minimatch": "^3.0.0",
 		"vscode-languageserver": "^1.1.0",
 		"semver": "^5.1.0"
 	},

--- a/tslint-server/src/server.ts
+++ b/tslint-server/src/server.ts
@@ -13,6 +13,7 @@ interface Settings {
 		enable: boolean;
 		rulesDirectory: string;
 		configFile: string;
+		ignoreDefinitionFiles: boolean;
 		exclude: string | string[];
 	};
 }
@@ -148,16 +149,22 @@ function doValidate(conn: server.IConnection, document: server.ITextDocument): s
 		return diagnostics;
 	}
 
-	if (settings && settings.tslint && settings.tslint.exclude) {
-		if (Array.isArray(settings.tslint.exclude)) {
-			for (var pattern of settings.tslint.exclude) {
-				if (minimatch(fsPath, pattern)) {
-					return diagnostics;
-				}
+	if (settings && settings.tslint) {
+		if (settings.tslint.ignoreDefinitionFiles) {
+			if (minimatch(fsPath, "**/*.d.ts")) {
+				return diagnostics;
 			}
 		}
-		else {
-			if (minimatch(fsPath, <string>settings.tslint.exclude)) {
+
+		if (settings.tslint.exclude) {
+			if (Array.isArray(settings.tslint.exclude)) {
+				for (var pattern of settings.tslint.exclude) {
+					if (minimatch(fsPath, pattern)) {
+						return diagnostics;
+					}
+				}
+			}
+			else if (minimatch(fsPath, <string>settings.tslint.exclude)) {
 				return diagnostics;
 			}
 		}

--- a/tslint-server/src/typings/minimatch/minimatch.d.ts
+++ b/tslint-server/src/typings/minimatch/minimatch.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for Minimatch 2.0.8
+// Project: https://github.com/isaacs/minimatch
+// Definitions by: vvakame <https://github.com/vvakame/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "minimatch" {
+
+	function M(target: string, pattern: string, options?: M.IOptions): boolean;
+
+	namespace M {
+		function match(list: string[], pattern: string, options?: IOptions): string[];
+		function filter(pattern: string, options?: IOptions): (element: string, indexed: number, array: string[]) => boolean;
+		function makeRe(pattern: string, options?: IOptions): RegExp;
+
+		var Minimatch: IMinimatchStatic;
+
+		interface IOptions {
+			debug?: boolean;
+			nobrace?: boolean;
+			noglobstar?: boolean;
+			dot?: boolean;
+			noext?: boolean;
+			nocase?: boolean;
+			nonull?: boolean;
+			matchBase?: boolean;
+			nocomment?: boolean;
+			nonegate?: boolean;
+			flipNegate?: boolean;
+		}
+
+		interface IMinimatchStatic {
+			new (pattern: string, options?: IOptions): IMinimatch;
+			prototype: IMinimatch;
+		}
+
+		interface IMinimatch {
+			pattern: string;
+			options: IOptions;
+			/** 2-dimensional array of regexp or string expressions. */
+			set: any[][]; // (RegExp | string)[][]
+			regexp: RegExp;
+			negate: boolean;
+			comment: boolean;
+			empty: boolean;
+
+			makeRe(): RegExp; // regexp or boolean
+			match(fname: string): boolean;
+			matchOne(files: string[], pattern: string[], partial: boolean): boolean;
+
+			/** Deprecated. For internal use. */
+			debug(): void;
+			/** Deprecated. For internal use. */
+			make(): void;
+			/** Deprecated. For internal use. */
+			parseNegate(): void;
+			/** Deprecated. For internal use. */
+			braceExpand(pattern: string, options: IOptions): void;
+			/** Deprecated. For internal use. */
+			parse(pattern: string, isSub?: boolean): void;
+		}
+	}
+
+	export = M;
+}

--- a/tslint/README.md
+++ b/tslint/README.md
@@ -15,6 +15,8 @@ When you are using TypeScript version 1.7 then at least version 3.1.1 is require
 - `tslint.enable` - enable/disable tslint.
 - `tslint.rulesDirectory` - an additional rules directory, for user-created rules.
 - `tslint.configFile` - the configuration file that tslint should use instead of the default `tslint.json`.
+- `tslint.ignoreDefinitionFiles` - control if TypeScript definition files should be ignored.
+- `tslint.exclude` - configure glob patterns of file paths to exclude from linting.
 
 
 # Release Notes

--- a/tslint/package.json
+++ b/tslint/package.json
@@ -48,6 +48,11 @@
 					"description": "The path to the rules configuration file",
 					"default": ""
 				},
+				"tslint.ignoreDefinitionFiles": {
+					"type": "boolean",
+					"default": true,
+					"description": "Control if TypeScript definition files should be ignored"
+				},
 				"tslint.exclude": {
 					"type": ["string", "array"],
 					"items": {

--- a/tslint/package.json
+++ b/tslint/package.json
@@ -47,6 +47,13 @@
 					"type": "string",
 					"description": "The path to the rules configuration file",
 					"default": ""
+				},
+				"tslint.exclude": {
+					"type": ["string", "array"],
+					"items": {
+						"type": "string"
+					},
+					"description": "Configure glob patterns of file paths to exclude from linting"
 				}
 			}
 		},


### PR DESCRIPTION
Add ignoreDefinitionFiles setting that defaults to true. #27
Add exclude setting that can be set to one or more glob patterns. Matched files are excluded from linting. #23 While the issue on the tslint repo is getting _some_ attention, it's been far too long.

I refactored doValidate so it returns the list of diagnostics. This is so vscode will properly update the lint errors when changing the settings around.