### PR TITLE
Add simple lint on save support (closes #21)

### DIFF
--- a/tslint-server/src/server.ts
+++ b/tslint-server/src/server.ts
@@ -18,6 +18,7 @@ interface Settings {
 		ignoreDefinitionFiles: boolean;
 		exclude: string | string[];
 		validateWithDefaultConfig: boolean;
+		run: 'onSave' | 'onType';
 	};
 }
 
@@ -337,7 +338,24 @@ function fileIsExcluded(path: string): boolean {
 // A text document has changed. Validate the document.
 documents.onDidChangeContent((event) => {
 	// the contents of a text document has changed, trigger a delayed validation
-	triggerValidateDocument(event.document);
+	if (settings.tslint.run === 'onType') {
+		triggerValidateDocument(event.document);
+	} else if (settings.tslint.run === 'onSave') {
+		// Clear the linting state so we don't show stale linting state
+		connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+	}
+});
+
+documents.onDidOpen((event) => {
+	if (settings.tslint.run === 'onSave') {
+		triggerValidateDocument(event.document);
+	}
+})
+
+documents.onDidSave((event) => {
+	if (settings.tslint.run === 'onSave') {
+		triggerValidateDocument(event.document);
+	}
 });
 
 // A text document was closed. Clear the diagnostics .

--- a/tslint/package.json
+++ b/tslint/package.json
@@ -70,6 +70,12 @@
 						"type": "string"
 					},
 					"description": "Configure glob patterns of file paths to exclude from linting"
+				},
+				"tslint.run": {
+					"type": "string",
+					"enum": ["onSave", "onType"],
+					"default": "onType",
+					"description": "Whether the linter is run on save (onSave) or on type (onType)"
 				}
 			}
 		},


### PR DESCRIPTION
I found constant linting updates really distracting while writing code, so I went ahead and implemented this. It uses the same setting format that the built-in PHP linter extension uses:

```
  // Whether the linter is run on save (onSave) or on type (onType)
  "tslint.run": "onType",
```

My first pass at this actually removed the 200ms delay on validation when in onSave mode, but I ran into a couple annoying problems:

* `onDidChangeContent` is fired after `onDidOpen` and would clear the validation state on open
* ` onDidChangeContent` and `onDidSave` would be fired around the same time if I quickly saved after making a chance, and this lead to a common race condition where the state would get cleared after a save.

I couldn't think of a better way to avoid these issues without tracking a lot of extra state, and figured the 200ms delay is long enough that I don't think you'd ever see a race condition but short enough that it isn't painful.