### PR TITLE
fixed regexp pattern, violated rule was missing

### DIFF
--- a/tslint/README.md
+++ b/tslint/README.md
@@ -76,7 +76,7 @@ Next define a Task which runs the gulp task with a problem matcher that extracts
 			],
 			"severity": "warning",
 			"pattern": {
-				"regexp": "^(\\S.*)\\[(\\d+), (\\d+)\\]:\\s+(.*)$",
+				"regexp": "^\\(\\S.*\\) (\\S.*)\\[(\\d+), (\\d+)\\]:\\s+(.*)$",
 				"file": 1,
 				"line": 2,
 				"column": 3,


### PR DESCRIPTION
The current regexp pattern does not take the rule name into account which results in file names like the following (which of course cannot be opened by VS Code):
`(no-shadowed-variable) src/...`