### PR TITLE
fix most of the autoFix issues using TSLint 4.0

### DIFF
--- a/tslint-server/src/server.ts
+++ b/tslint-server/src/server.ts
@@ -6,7 +6,7 @@
 import * as minimatch from 'minimatch';
 import * as server from 'vscode-languageserver';
 import * as fs from 'fs';
-import * as semver from 'semver'
+import * as semver from 'semver';
 
 import * as vscFixLib from './vscFix';
 
@@ -168,15 +168,26 @@ function recordCodeAction(document: server.TextDocument, diagnostic: server.Diag
 	let fixStart: TSLintPosition;
 	let fixEnd: TSLintPosition;
 
-	// console.log("----------***************************", problem);
-
 	// check tsl fix
 	if (!!problem.fix) {
+
+		console.log("Problem.fix:\n",problem.fix);
 		fixText = problem.fix.innerReplacements[0].innerText;
-		// fixStart = problem.fix.innerReplacements[0].innerStart;
-		// fixEnd = problem.fix.innerReplacements[0].innerStart + problem.fix.innerReplacements[0].innerLength;
-		fixStart = problem.startPosition;
-		fixEnd = problem.endPosition;
+
+		// convert offset in position
+		fixStart =  Object.assign(
+			{},
+			document.positionAt(problem.fix.innerReplacements[0].innerStart),
+			{position: problem.fix.innerReplacements[0].innerStart}
+			);
+
+		const positionEnd = problem.fix.innerReplacements[0].innerStart + problem.fix.innerReplacements[0].innerLength;
+		fixEnd = Object.assign(
+			{},
+			document.positionAt(positionEnd),
+			{position: positionEnd}
+			);
+		fixEnd.position = problem.fix.innerReplacements[0].innerStart+problem.fix.innerReplacements[0].innerLength;
 	}
 
 	//check vsc fix

--- a/tslint-tests/package.json
+++ b/tslint-tests/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tslint-issues",
+  "version": "1.0.0",
+  "description": "dummy project containing dummies files to raise tslint problems and check that correction are working fine",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "typescript": "^2.0.10"
+  }
+}

--- a/tslint-tests/tests/arrow-parens.ts
+++ b/tslint-tests/tests/arrow-parens.ts
@@ -1,0 +1,1 @@
+[1, 2 ].map( num => console.log(num) );

--- a/tslint-tests/tests/no-var-keyword.ts
+++ b/tslint-tests/tests/no-var-keyword.ts
@@ -1,0 +1,10 @@
+// This autoFix provide several innerReplacements
+// !! not yet supported !!
+//  innerReplacements: 
+//    [ { innerStart: 36, innerLength: 3, innerText: '' },
+//      { innerStart: 36, innerLength: 0, innerText: 'let' } ] }
+
+
+var anakin: string = "jedi";
+
+console.log(`variable is used:${anakin}`);

--- a/tslint-tests/tests/no_unused-variable.ts
+++ b/tslint-tests/tests/no_unused-variable.ts
@@ -1,0 +1,5 @@
+import {  } from "diff";
+
+import { A, B } from "parse-json";
+
+console.log(`use ${A}`);

--- a/tslint-tests/tests/ordered-imports.ts
+++ b/tslint-tests/tests/ordered-imports.ts
@@ -1,0 +1,4 @@
+import {B, A, C} from "diff";
+import {D, E} from "diff";
+
+console.log(`use ${A} ${B} ${C} ${D}, ${E}`);

--- a/tslint-tests/tests/semicolon.ts
+++ b/tslint-tests/tests/semicolon.ts
@@ -1,0 +1,2 @@
+let test1: string
+console.log(`use ${test1}`)

--- a/tslint-tests/tests/trailing-comma.ts
+++ b/tslint-tests/tests/trailing-comma.ts
@@ -1,0 +1,8 @@
+// a comma is missing at the end
+
+let test = {
+  lastName: user.lastName,
+  missAComma: "mis"
+};
+
+console.log(test); 

--- a/tslint-tests/tsconfig.json
+++ b/tslint-tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "noImplicitAny": false,
+        "sourceMap": false
+    }
+}

--- a/tslint-tests/tslint.json
+++ b/tslint-tests/tslint.json
@@ -1,0 +1,62 @@
+{
+    "rules": {
+        "arrow-parens": true,
+        "no-var-keyword": true,
+        "no-unused-variable": [true, {"ignore-pattern": "^_"}],
+        "ordered-imports": [true, {"import-sources-order": "lowercase-last", "named-imports-order": "lowercase-first"}],
+        "trailing-comma": [true, {"multiline": "always", "singleline": "never"}],
+
+        "class-name": true,
+        "comment-format": [
+            true,
+            "check-space"
+        ],
+        "indent": [
+            true,
+            "spaces"
+        ],
+        "no-eval": true,
+        "no-internal-module": true,
+        "no-trailing-whitespace": true,
+        "no-unsafe-finally": true,
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-whitespace"
+        ],
+        "quotemark": [
+            true,
+            "double"
+        ],
+        "semicolon": [
+            true,
+            "always"
+        ],
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "typedef-whitespace": [
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            }
+        ],
+        "variable-name": [
+            true,
+            "ban-keywords"
+        ],
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ]
+    }
+}


### PR DESCRIPTION
Hi @egamma 

 Here is a proposal of fix for most of the autoFix issue identified since TSLint 4.0. #135 

Actions done:
* convert the offset in position
* add a sub `tslint-tests` at the root of vscode-tslint to collect some tests cases used in these days

Remaining activities identified:
* `no-var-keyword` still not supported. This autoFix need more work in the alogrithm. This is the only one not working. => To Do : support multiple inner replacements
* during the tests I've got the 'innerText' from undefined error ... without the opportunity to reproduce.
* there is a tsc error in the server code but does not prohibit emit
````		
if (configurationResult.error) {
   throw configurationResult.error;
}
````

I let you have trial on this proposal, it should help.

BR
