### PR TITLE
Detect 4.0.0 for -dev versions of tslint

### DIFF
--- a/tslint-server/src/server.ts
+++ b/tslint-server/src/server.ts
@@ -322,7 +322,7 @@ function isTsLintVersion4(linter) {
 		version = linter.VERSION;
 	} catch (e) {
 	}
-	return semver.gte(version, '4.0.0');
+	return semver.satisfies(version, ">= 4.0.0 || >= 4.0.0-dev");
 }
 
 function doValidate(conn: server.IConnection, document: server.TextDocument): server.Diagnostic[] {


### PR DESCRIPTION
tslint only works with nightly versions of typescript on the 4.0.0-dev.* releases. 

This means the `linter.findConfiguration` issue crops up on projects that are using nightly typescript.

An example project that demonstrates this is https://github.com/ericanderson/sample-break-vscode-tslint
