### PR TITLE
Update tslint-tests

### DIFF
--- a/tslint-tests/gulpfile.js
+++ b/tslint-tests/gulpfile.js
@@ -10,3 +10,5 @@ gulp.task('tslint', () => {
           emitError: false
       }));
 });
+
+gulp.task('default', ["tslint"]);

--- a/tslint-tests/package.json
+++ b/tslint-tests/package.json
@@ -10,10 +10,10 @@
   "license": "ISC",
   "dependencies": {
     "gulp": "^3.9.1",
-    "gulp-tslint": "^7.1.0",
+    "gulp-tslint": "^8.0.0",
     "tslint": "^5.0.0"
   },
   "devDependencies": {
-    "typescript": "^2.0.10"
+    "typescript": "^2.2.2"
   }
 }


### PR DESCRIPTION
TSLint 5.0 require TS 2.1 or heighter (https://github.com/palantir/tslint/releases/tag/5.0.0). 
And gulp-tslint 8.0 support TSLint 5.0.