### PR TITLE
When autoFixOnSave is array, items must be strings

### DIFF
--- a/tslint/package.json
+++ b/tslint/package.json
@@ -105,6 +105,9 @@
             "boolean",
             "array"
           ],
+          "items": {
+            "type": "string"
+          },
           "default": false,
           "description": "Turns auto fix on save on or off, or defines which rules (e.g. `no-var-keyword`) to auto fix on save."
         },


### PR DESCRIPTION
Was looking into possible validation for the `autoFixOnSave` setting, and found the `items` property.

When `items` is set with a `type`, and `autoFixOnSave` is an array, it enforces the items in the array to being that type, and will show a green squiggly under it with a message if it isn't the desired type.