### PR TITLE
bump tslint extension vscode engine

### DIFF
--- a/tslint/package.json
+++ b/tslint/package.json
@@ -23,7 +23,7 @@
     "Linters"
   ],
   "engines": {
-    "vscode": "^0.10.0"
+    "vscode": "^1.15.0"
   },
   "activationEvents": [
     "onLanguage:typescript",


### PR DESCRIPTION
Compilation fails with vscode.d.ts from ^0.10.0 (an old version that exports declarations in a different way from current vscode.d.ts releases).

There are many errors from `tsc`; the first is:

```
extension.ts(3,39): error TS2305: Module ''vscode'' has no exported member 'QuickPickItem'.
```

This PR makes compilation succeed for me.