### PR TITLE
[Discussion] [Live Share] Restricting linting to local files

### DIFF
--- a/tslint/extension.ts
+++ b/tslint/extension.ts
@@ -8,6 +8,7 @@ import {
 } from 'vscode-languageclient';
 import { exec }  from 'child_process';
 import * as open from 'open';
+import flatMap = require("lodash.flatmap");
 
 interface AllFixesParams {
 	readonly textDocument: TextDocumentIdentifier;
@@ -155,8 +156,13 @@ export function activate(context: ExtensionContext) {
 		debug: { module: serverModulePath, transport: TransportKind.ipc, options: debugOptions }
 	};
 
+	const documentSelector = flatMap(['typescript', 'typescriptreact', 'javascript', 'javascriptreact'], language => [
+		{ language, scheme: 'file' },
+		{ language, scheme: 'untitled' }
+	]);
+
 	let clientOptions: LanguageClientOptions = {
-		documentSelector: ['typescript', 'typescriptreact', 'javascript', 'javascriptreact'],
+		documentSelector,
 		synchronize: {
 			configurationSection: 'tslint',
 			fileEvents: workspace.createFileSystemWatcher('**/tslint.{json,yml,yaml}')

--- a/tslint/package-lock.json
+++ b/tslint/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/lodash": {
+      "version": "4.14.106",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.106.tgz",
+      "integrity": "sha512-tOSvCVrvSqFZ4A/qrqqm6p37GZoawsZtoR0SJhlF7EonNZUgrn8FfT+RNQ11h+NUpMt6QVe36033f3qEKBwfWA==",
+      "dev": true
+    },
+    "@types/lodash.flatmap": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatmap/-/lodash.flatmap-4.5.3.tgz",
+      "integrity": "sha512-0+aQVPOiJgcYoo87AyUW12HxbOL+ApPAAVpwzzMJgyEYu8dev8OPLT6tp7FKLK4F3wlfcAqwdiYT+0R4xe9aiQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "4.14.106"
+      }
+    },
     "@types/mocha": {
       "version": "2.2.46",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.46.tgz",
@@ -1660,6 +1675,11 @@
       "requires": {
         "lodash._root": "3.0.1"
       }
+    },
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
     },
     "lodash.isarguments": {
       "version": "3.1.0",

--- a/tslint/package.json
+++ b/tslint/package.json
@@ -240,6 +240,7 @@
     "update-vscode": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
+    "@types/lodash.flatmap": "^4.5.3",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.40",
     "typescript": "^2.4.2",
@@ -247,6 +248,7 @@
   },
   "dependencies": {
     "global": "^4.3.2",
+    "lodash.flatmap": "^4.5.0",
     "open": "^0.0.5",
     "vsce": "^1.35.0",
     "vscode-languageclient": "^3.5.0-next.4"


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services from a host, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the TSLint extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience.

// CC @egamma 